### PR TITLE
Updating so URLs match the pilots protocol

### DIFF
--- a/technical/standalone-pilot-integration-steps.md
+++ b/technical/standalone-pilot-integration-steps.md
@@ -40,8 +40,8 @@ Your pilot will need to include links to BBC Terms & Conditions documents.
 Typically you would place these links at the bottom of the screen, using HTML markup similar to:
 
 ```
-<a href="http://www.bbc.co.uk/privacy/information/policy/"target="_blank">Privacy policy</a> |
-<a href="http://www.bbc.co.uk/terms" target="_blank">Terms and conditions</a>
+<a href="//www.bbc.co.uk/privacy/information/policy/"target="_blank">Privacy policy</a> |
+<a href="//www.bbc.co.uk/terms" target="_blank">Terms and conditions</a>
 ```
 
 ## Cookie Warning

--- a/technical/taster-classic-badge-integration.md
+++ b/technical/taster-classic-badge-integration.md
@@ -9,13 +9,13 @@ There are several components and specifications that must be included in your si
 1. The head of the document should contain the following script tag:
 
   ```
-  <script type="text/javascript" src="http://www.bbc.co.uk/taster/pilot-lib.js"></script>
+  <script type="text/javascript" src="//www.bbc.co.uk/taster/pilot-lib.js"></script>
   ```
 
 2. The iframe (which contains the quickrate badge) should be placed on the page with the following lines which initiate an iFrame pointed at the classic badge for your pilot. Please note that `<pilot-id>` should be replaced with the pilot ID that you have been assigned (if you are uncertain of these settings, please speak to the Taster team or refer to the Testing section at the end of this document):
 
   ```
-  <iframe class="taster-offsite-panel" src="http://www.bbc.co.uk/taster/projects/<pilot-id>/offsite/rate" frameborder="0" scrolling="no"></iframe>
+  <iframe class="taster-offsite-panel" src="//www.bbc.co.uk/taster/projects/<pilot-id>/offsite/rate" frameborder="0" scrolling="no"></iframe>
   ```
 
 3. At the end of the HTML document, the following code should be entered:
@@ -47,7 +47,7 @@ The badge will not be fully active, and interacting it will return a 404 page on
 1. In order to test the rating version of the badge in an iFrame, please redirect the iframe to a test URL as shown in the following example code:
 
   ```
-  <iframe class="taster-offsite-panel" src="http://www.test.bbc.co.uk/taster/projects/automatedtestpilot/offsite/rate" frameborder="0" scrolling="no"></iframe>
+  <iframe class="taster-offsite-panel" src="//www.test.bbc.co.uk/taster/projects/automatedtestpilot/offsite/rate" frameborder="0" scrolling="no"></iframe>
   ```
 
 **This cannot be delivered to us in the final version. Please ensure that this is for testing only, and update to the correct version as per the instructions outlined in section 2 above.**

--- a/technical/taster-slim-badge-integration.md
+++ b/technical/taster-slim-badge-integration.md
@@ -9,13 +9,13 @@ There are several components and specifications that must be included in your si
 1. The head of the document should contain the following script tag:
 
   ```
-  <script type="text/javascript" src="http://www.bbc.co.uk/taster/pilot-lib-slim.js"></script>
+  <script type="text/javascript" src="//www.bbc.co.uk/taster/pilot-lib-slim.js"></script>
   ```
 
 2. The iframe (which contains the quickrate badge) should be placed on the page with the following lines which initiate an iFrame pointed at the slim badge for your pilot. Please note that `<pilot-id>` should be replaced with the pilot ID that you have been assigned (if you are uncertain of this, please speak to the Taster team or refer to the Testing section at the end of this document):
 
   ```
-  <iframe class="taster-offsite-panel" src="http://www.bbc.co.uk/taster/projects/<pilot-id>/offsite/slim" frameborder="0" scrolling="no"></iframe>
+  <iframe class="taster-offsite-panel" src="//www.bbc.co.uk/taster/projects/<pilot-id>/offsite/slim" frameborder="0" scrolling="no"></iframe>
   ```
 
 3. At the end of the HTML document, the following code should be entered:
@@ -49,11 +49,11 @@ The badge will not be fully active, and interacting it will return a 404 page on
 1. In order to test the iFrame, please redirect the iframe to a test URL as shown in the following example code:
 
   ```
-  <iframe class="taster-offsite-panel" src="http://www.test.bbc.co.uk/taster/projects/automatedtestpilot/offsite/slim" frameborder="0" scrolling="no"></iframe>
+  <iframe class="taster-offsite-panel" src="//www.test.bbc.co.uk/taster/projects/automatedtestpilot/offsite/slim" frameborder="0" scrolling="no"></iframe>
   ```
 
 **This cannot be delivered to us in the final version. Please ensure that this is for testing only, and update to the correct version as per the instructions outlined in section 2 above.**
 
-### Please do not forget to add the legal links and cookie warnings as described in the [**Pilot Integration Guide**](standalone-pilot-integration-steps.md) 
+### Please do not forget to add the legal links and cookie warnings as described in the [**Pilot Integration Guide**](standalone-pilot-integration-steps.md)
 
 ### If you require any additional information or support, or you wish to make any changes to the instructions above, please contact a member of the Taster Team (tastertech@rd.bbc.co.uk).


### PR DESCRIPTION
As the new standard is to make pilots HTTPS updated the docs so that links and scripts are pulled in using the same protocol as the viewer